### PR TITLE
Fix tag equality logic in TagPickerView

### DIFF
--- a/DeckBox/Views/TagManagementView.swift
+++ b/DeckBox/Views/TagManagementView.swift
@@ -373,8 +373,8 @@ struct TagPickerView: View {
         List {
             ForEach(allTags) { tag in
                 Button(action: {
-                    if selectedTags.contains(tag) {
-                        selectedTags.removeAll { $0 == tag }
+                    if selectedTags.contains(where: { $0.id == tag.id }) {
+                        selectedTags.removeAll { $0.id == tag.id }
                     } else {
                         selectedTags.append(tag)
                     }
@@ -386,7 +386,7 @@ struct TagPickerView: View {
 
                         Text(tag.name)
                         Spacer()
-                        if selectedTags.contains(tag) {
+                        if selectedTags.contains(where: { $0.id == tag.id }) {
                             Image(systemName: "checkmark")
                         }
                     }


### PR DESCRIPTION
## Summary
- fix tag equality checks to compare IDs

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project DeckBox.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6450c138832bb7555baa823b54c5