### PR TITLE
Add tests for CardGroup quantity management

### DIFF
--- a/DeckBoxTests/DeckBoxTests.swift
+++ b/DeckBoxTests/DeckBoxTests.swift
@@ -6,11 +6,31 @@
 //
 
 import Testing
+@testable import DeckBox
 
 struct DeckBoxTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test("setQuantity > 0 adds card")
+    func testSetQuantityAddsCard() async throws {
+        let card = Card(game: "Magic", name: "Island", quantity: 4)
+        let group = CardGroup(name: "Test Group", type: nil)
+
+        group.setQuantity(3, for: card)
+
+        #expect(group.cards.contains(where: { $0.id == card.id }))
+        #expect(group.quantity(for: card) == 3)
+    }
+
+    @Test("setQuantity 0 removes card")
+    func testSetQuantityRemovesCard() async throws {
+        let card = Card(game: "Magic", name: "Island", quantity: 4)
+        let group = CardGroup(name: "Test Group", type: nil)
+
+        group.setQuantity(2, for: card)
+        group.setQuantity(0, for: card)
+
+        #expect(!group.cards.contains(where: { $0.id == card.id }))
+        #expect(group.quantity(for: card) == 0)
     }
 
 }


### PR DESCRIPTION
## Summary
- verify CardGroup.setQuantity correctly handles adding and removing cards

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683f66ffac2c832b8fca81c08021b790