### PR TITLE
Improve tag visibility with border

### DIFF
--- a/DeckBox/Extensions/Color+MTG.swift
+++ b/DeckBox/Extensions/Color+MTG.swift
@@ -131,4 +131,91 @@ extension Color {
             opacity: Double(a) / 255
         )
     }
+}
+
+// MARK: - Tag Color Extensions
+extension Color {
+    /// Returns a tag background color that adapts to the current color scheme
+    /// - Parameters:
+    ///   - colorName: The name of the color to use
+    ///   - colorScheme: The current color scheme (light or dark)
+    /// - Returns: A color suitable for tag backgrounds in the current color scheme
+    static func tagBackground(colorName: String, colorScheme: ColorScheme) -> Color {
+        switch colorScheme {
+        case .light:
+            // In light mode, handle white tags specially
+            switch colorName {
+            case "mtgWhite":
+                return Color(.systemGray5)
+            default:
+                return Color.fromName(colorName).opacity(0.15)
+            }
+        case .dark:
+            // In dark mode, handle black tags specially
+            switch colorName {
+            case "mtgBlack":
+                return Color(.systemGray3)
+            default:
+                return Color.fromName(colorName).opacity(0.4)
+            }
+        @unknown default:
+            return Color.fromName(colorName).opacity(0.2)
+        }
+    }
+    
+    /// Returns a tag text color that ensures readability against the background
+    /// - Parameters:
+    ///   - colorName: The name of the color to use
+    ///   - colorScheme: The current color scheme (light or dark)
+    /// - Returns: A color suitable for tag text in the current color scheme
+    static func tagText(colorName: String, colorScheme: ColorScheme) -> Color {
+        switch colorScheme {
+        case .light:
+            // In light mode, ensure white tags have readable text
+            switch colorName {
+            case "mtgWhite":
+                return .black
+            default:
+                return Color.fromName(colorName).opacity(0.8)
+            }
+        case .dark:
+            // In dark mode, ensure black tags have readable text
+            switch colorName {
+            case "mtgBlack":
+                return .white
+            default:
+                return Color.fromName(colorName).opacity(0.9)
+            }
+        @unknown default:
+            return Color.fromName(colorName)
+        }
+    }
+    
+    /// Returns a tag border color that provides good contrast
+    /// - Parameters:
+    ///   - colorName: The name of the color to use
+    ///   - colorScheme: The current color scheme (light or dark)
+    /// - Returns: A color suitable for tag borders in the current color scheme
+    static func tagBorder(colorName: String, colorScheme: ColorScheme) -> Color {
+        switch colorScheme {
+        case .light:
+            // In light mode, ensure white tags have visible borders
+            switch colorName {
+            case "mtgWhite":
+                return Color(.systemGray3)
+            default:
+                return Color.fromName(colorName).opacity(0.3)
+            }
+        case .dark:
+            // In dark mode, ensure black tags have visible borders
+            switch colorName {
+            case "mtgBlack":
+                return Color(.systemGray)
+            default:
+                return Color.fromName(colorName).opacity(0.6)
+            }
+        @unknown default:
+            return Color.fromName(colorName).opacity(0.4)
+        }
+    }
 } 

--- a/DeckBox/Views/CardDetailView.swift
+++ b/DeckBox/Views/CardDetailView.swift
@@ -16,6 +16,7 @@ struct CardDetailView: View {
     /// The card being displayed and edited
     @Bindable var card: Card             // SwiftData auto–bindable
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.colorScheme) private var colorScheme
 
     // MARK: - View State
     
@@ -68,16 +69,21 @@ struct CardDetailView: View {
                                 .frame(width: 8, height: 8)
                                 .overlay(
                                     Circle()
-                                        .stroke(Color.primary, lineWidth: 1)
+                                        .stroke(Color.tagBorder(colorName: tag.color, colorScheme: colorScheme), lineWidth: 1)
                                 )
                             Text(tag.name)
+                                .foregroundColor(Color.tagText(colorName: tag.color, colorScheme: colorScheme))
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.secondary)
                                 .font(.caption)
                         }
                         .padding(.vertical, 4)
                         .padding(.horizontal, 8)
-                        .background(Color.fromName(tag.color).opacity(0.2))
+                        .background(Color.tagBackground(colorName: tag.color, colorScheme: colorScheme))
+                        .overlay(
+                            Capsule()
+                                .stroke(Color.tagBorder(colorName: tag.color, colorScheme: colorScheme), lineWidth: 1)
+                        )
                         .clipShape(Capsule())
                         .onTapGesture {
                             if let idx = card.tags.firstIndex(where: { $0.name == tag.name }) {

--- a/DeckBox/Views/CardDetailView.swift
+++ b/DeckBox/Views/CardDetailView.swift
@@ -66,6 +66,10 @@ struct CardDetailView: View {
                             Circle()
                                 .fill(Color.fromName(tag.color))
                                 .frame(width: 8, height: 8)
+                                .overlay(
+                                    Circle()
+                                        .stroke(Color.primary, lineWidth: 1)
+                                )
                             Text(tag.name)
                             Image(systemName: "xmark.circle.fill")
                                 .foregroundStyle(.secondary)
@@ -109,6 +113,10 @@ struct CardDetailView: View {
                                 Circle()
                                     .fill(Color(tag.color))
                                     .frame(width: 12, height: 12)
+                                    .overlay(
+                                        Circle()
+                                            .stroke(Color.primary, lineWidth: 1)
+                                    )
                                 Text(tag.name)
                                 if let category = tag.category {
                                     Spacer()

--- a/DeckBox/Views/CardGroupDetailView.swift
+++ b/DeckBox/Views/CardGroupDetailView.swift
@@ -39,6 +39,10 @@ struct CardGroupDetailView: View {
                                 Circle()
                                     .fill(Color.fromName(tag.color))
                                     .frame(width: 8, height: 8)
+                                    .overlay(
+                                        Circle()
+                                            .stroke(Color.primary, lineWidth: 1)
+                                    )
                             }
                             if card.tags.count > 3 {
                                 Text("+\(card.tags.count - 3)")

--- a/DeckBox/Views/CardGroupDetailView.swift
+++ b/DeckBox/Views/CardGroupDetailView.swift
@@ -1,6 +1,76 @@
 import SwiftUI
 import SwiftData
 
+// MARK: - Card Tag Display
+/// A view that displays up to 3 tags for a card with an overflow indicator
+private struct CardTagDisplay: View {
+    let tags: [Tag]
+    @Environment(\.colorScheme) private var colorScheme
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(tags.prefix(3), id: \.name) { tag in
+                HStack(spacing: 2) {
+                    Circle()
+                        .fill(Color.fromName(tag.color))
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .stroke(Color.tagBorder(colorName: tag.color, colorScheme: colorScheme), lineWidth: 1)
+                        )
+                }
+                .padding(.vertical, 2)
+                .padding(.horizontal, 4)
+                .background(Color.tagBackground(colorName: tag.color, colorScheme: colorScheme))
+                .clipShape(Capsule())
+                .overlay(
+                    Capsule()
+                        .stroke(Color.tagBorder(colorName: tag.color, colorScheme: colorScheme), lineWidth: 1)
+                )
+            }
+            if tags.count > 3 {
+                Text("+\(tags.count - 3)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+}
+
+// MARK: - Card Row View
+/// A view that displays a single card row in the group
+private struct CardRowView: View {
+    let card: Card
+    let group: CardGroup
+    
+    var body: some View {
+        NavigationLink(value: card) {
+            HStack {
+                // Card name display
+                Text(card.name)
+                    .font(.headline)
+                    .lineLimit(1)
+                
+                Spacer()
+                
+                // Quantity indicator
+                Text("×\(group.quantity(for: card))")
+                    .foregroundStyle(.secondary)
+                
+                // Tag visualization
+                CardTagDisplay(tags: card.tags)
+            }
+        }
+        .swipeActions(edge: .trailing) {
+            Button(role: .destructive) {
+                group.setQuantity(0, for: card)
+            } label: {
+                Label("Remove", systemImage: "minus.circle")
+            }
+        }
+    }
+}
+
 // MARK: - Card Group Detail View
 /// A view that displays the details of a card group, including a list of cards and their quantities.
 /// Allows for navigation to card details and adding new cards to the group.
@@ -19,47 +89,7 @@ struct CardGroupDetailView: View {
         List {
             // Display each card in the group with its quantity and tags
             ForEach(sortedCards) { card in
-                NavigationLink(value: card) {
-                    HStack {
-                        // Card name display
-                        Text(card.name)
-                            .font(.headline)
-                            .lineLimit(1)
-                        
-                        Spacer()
-                        
-                        // Quantity indicator
-                        Text("×\(group.quantity(for: card))")
-                            .foregroundStyle(.secondary)
-                        
-                        // Tag visualization section
-                        // Shows up to 3 tags as colored circles, with a count for additional tags
-                        HStack(spacing: 4) {
-                            ForEach(card.tags.prefix(3), id: \.name) { tag in
-                                Circle()
-                                    .fill(Color.fromName(tag.color))
-                                    .frame(width: 8, height: 8)
-                                    .overlay(
-                                        Circle()
-                                            .stroke(Color.primary, lineWidth: 1)
-                                    )
-                            }
-                            if card.tags.count > 3 {
-                                Text("+\(card.tags.count - 3)")
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                    }
-                }
-                // Swipe action to remove card from group
-                .swipeActions(edge: .trailing) {
-                    Button(role: .destructive) {
-                        group.setQuantity(0, for: card)
-                    } label: {
-                        Label("Remove", systemImage: "minus.circle")
-                    }
-                }
+                CardRowView(card: card, group: group)
             }
         }
         .navigationTitle(group.name)
@@ -85,6 +115,57 @@ struct CardGroupDetailView: View {
     }
 }
 
+// MARK: - Card Selection Row View
+/// A view that displays a single card row in the card selection list
+private struct CardSelectionRowView: View {
+    let card: Card
+    let group: CardGroup
+    let remainingQuantity: Int
+    @Binding var selectedQuantities: [UUID: Int]
+    
+    var body: some View {
+        HStack {
+            // Card information section
+            VStack(alignment: .leading) {
+                HStack {
+                    Text(card.name)
+                    CardTagDisplay(tags: card.tags)
+                }
+                Text("Library: ×\(card.quantity) • In Group: ×\(group.quantity(for: card))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            
+            Spacer()
+            
+            if remainingQuantity > 0 {
+                // Quantity selection controls
+                Stepper(
+                    value: Binding(
+                        get: { selectedQuantities[card.id] ?? 1 },
+                        set: { selectedQuantities[card.id] = $0 }
+                    ),
+                    in: 1...remainingQuantity
+                ) {
+                    Text("\(selectedQuantities[card.id] ?? 1)")
+                        .monospacedDigit()
+                        .frame(minWidth: 25)
+                }
+                
+                // Add button
+                Button {
+                    let quantity = selectedQuantities[card.id] ?? 1
+                    group.setQuantity(group.quantity(for: card) + quantity, for: card)
+                    selectedQuantities[card.id] = 1 // Reset quantity
+                } label: {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundStyle(.blue)
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Card Selection View
 /// A view that allows users to select and add cards to a group.
 /// Includes search functionality and quantity selection for each card.
@@ -96,7 +177,6 @@ struct CardSelectionView: View {
     @State private var selectedQuantities: [UUID: Int] = [:]
     
     /// Filters cards based on search text and availability
-    /// Only shows cards that have remaining quantity available to add to the group
     private var filteredCards: [Card] {
         if searchText.isEmpty {
             return allCards.filter { card in
@@ -113,44 +193,13 @@ struct CardSelectionView: View {
     var body: some View {
         List {
             ForEach(filteredCards) { card in
-                HStack {
-                    // Card information section
-                    VStack(alignment: .leading) {
-                        Text(card.name)
-                        Text("Library: ×\(card.quantity) • In Group: ×\(group.quantity(for: card))")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    
-                    let remainingQuantity = card.quantity - group.quantity(for: card)
-                    if remainingQuantity > 0 {
-                        // Quantity selection controls
-                        // Allows users to specify how many copies of the card to add
-                        Stepper(
-                            value: Binding(
-                                get: { selectedQuantities[card.id] ?? 1 },
-                                set: { selectedQuantities[card.id] = $0 }
-                            ),
-                            // Limit the maximum quantity based on available cards
-                            in: 1...remainingQuantity
-                        ) {
-                            Text("\(selectedQuantities[card.id] ?? 1)")
-                                .monospacedDigit()
-                                .frame(minWidth: 25)
-                        }
-                        
-                        // Add button to confirm quantity selection
-                        Button {
-                            let quantity = selectedQuantities[card.id] ?? 1
-                            group.setQuantity(group.quantity(for: card) + quantity, for: card)
-                            selectedQuantities[card.id] = 1 // Reset quantity after adding
-                        } label: {
-                            Image(systemName: "plus.circle.fill")
-                                .foregroundStyle(.blue)
-                        }
-                    }
-                }
+                let remainingQuantity = card.quantity - group.quantity(for: card)
+                CardSelectionRowView(
+                    card: card,
+                    group: group,
+                    remainingQuantity: remainingQuantity,
+                    selectedQuantities: $selectedQuantities
+                )
             }
         }
         .searchable(text: $searchText, prompt: "Search cards...")

--- a/DeckBox/Views/CardListView.swift
+++ b/DeckBox/Views/CardListView.swift
@@ -260,7 +260,7 @@ struct CardListView: View {
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(selectedTags.isEmpty ? Color.mtgBlue.opacity(0.2) : Color(.systemGray6))
+                .background(selectedTags.isEmpty ? Color.tagBackground(colorName: "mtgBlue", colorScheme: colorScheme) : Color(.systemGray6))
                 .clipShape(Capsule())
                 .onTapGesture {
                     withAnimation(.easeInOut(duration: 0.2)) {
@@ -281,32 +281,19 @@ struct CardListView: View {
                         }
                         
                         ForEach(tags.sorted(by: { $0.name < $1.name }), id: \.id) { tag in
-                            let isSelected = selectedTags.contains(where: { $0.id == tag.id })
-                            let tagColor = Color.fromName(tag.color)
-                            HStack(spacing: 4) {
-                                Circle()
-                                    .fill(tagColor)
-                                    .frame(width: 8, height: 8)
-                                Text(tag.name)
-                                if tag.cards.count > 0 {
-                                    Text("\(tag.cards.count)")
-                                        .font(.caption)
-                                        .foregroundStyle(.secondary)
-                                }
-                            }
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(isSelected ? tagColor.opacity(0.2) : Color(.systemGray6))
-                            .clipShape(Capsule())
-                            .onTapGesture {
-                                withAnimation(.easeInOut(duration: 0.2)) {
-                                    if isSelected {
-                                        selectedTags.removeAll { $0.id == tag.id }
-                                    } else {
-                                        selectedTags.append(tag)
+                            TagFilterItem(
+                                tag: tag,
+                                isSelected: selectedTags.contains(where: { $0.id == tag.id }),
+                                action: {
+                                    withAnimation(.easeInOut(duration: 0.2)) {
+                                        if selectedTags.contains(where: { $0.id == tag.id }) {
+                                            selectedTags.removeAll { $0.id == tag.id }
+                                        } else {
+                                            selectedTags.append(tag)
+                                        }
                                     }
                                 }
-                            }
+                            )
                         }
                     }
                 }

--- a/DeckBox/Views/CardListView.swift
+++ b/DeckBox/Views/CardListView.swift
@@ -197,6 +197,10 @@ struct CardListView: View {
                                 Circle()
                                     .fill(tagColor)
                                     .frame(width: 8, height: 8)
+                                    .overlay(
+                                        Circle()
+                                            .stroke(Color.primary, lineWidth: 1)
+                                    )
                                 Text(tag.name)
                                 if tag.cards.count > 0 {
                                     Text("\(tag.cards.count)")
@@ -295,6 +299,10 @@ struct CardListView: View {
                                             Circle()
                                                 .fill(Color.fromName(tag.color))
                                                 .frame(width: 8, height: 8)
+                                                .overlay(
+                                                    Circle()
+                                                        .stroke(Color.primary, lineWidth: 1)
+                                                )
                                         }
                                         if card.tags.count > 3 {
                                             Text("+\(card.tags.count - 3)")

--- a/DeckBox/Views/TagManagementView.swift
+++ b/DeckBox/Views/TagManagementView.swift
@@ -71,6 +71,7 @@ struct TagManagementView: View {
 private struct TagRowView: View {
     /// The tag to display
     let tag: Tag
+    @Environment(\.colorScheme) private var colorScheme
     
     var body: some View {
         HStack {
@@ -80,7 +81,7 @@ private struct TagRowView: View {
                 .frame(width: 12, height: 12)
                 .overlay(
                     Circle()
-                        .stroke(Color.primary, lineWidth: 1)
+                        .stroke(Color.tagBorder(colorName: tag.color, colorScheme: colorScheme), lineWidth: 1)
                 )
             
             // Tag details

--- a/DeckBox/Views/TagManagementView.swift
+++ b/DeckBox/Views/TagManagementView.swift
@@ -78,6 +78,10 @@ private struct TagRowView: View {
             Circle()
                 .fill(Color.fromName(tag.color))
                 .frame(width: 12, height: 12)
+                .overlay(
+                    Circle()
+                        .stroke(Color.primary, lineWidth: 1)
+                )
             
             // Tag details
             VStack(alignment: .leading) {
@@ -383,6 +387,10 @@ struct TagPickerView: View {
                         Circle()
                             .fill(Color.fromName(tag.color))
                             .frame(width: 12, height: 12)
+                            .overlay(
+                                Circle()
+                                    .stroke(Color.primary, lineWidth: 1)
+                            )
 
                         Text(tag.name)
                         Spacer()


### PR DESCRIPTION
## Summary
- add a thin `Color.primary` stroke around tag indicator circles
- keep tag color options while ensuring visibility in both themes

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6847a52fd780832bb23e97c1d538f84a